### PR TITLE
require python 3.7 or higher in setup.py

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2
@@ -23,10 +23,9 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: pytest
+    - name: test pip install
       run: |
-        pip install -r dev-requirements.txt
-        # make test
+        pip install .
     - name: lint
       run: |
         pip install -r dev-requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,6 @@ setuptools.setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 3.7',
 
-    ]
+    ],
+    python_requires=">=3.7",
 )


### PR DESCRIPTION
this is necessary due to the usage of dataclasses, which were only added in python 3.7